### PR TITLE
Add: Add poolsize in order to prevent database pool init error

### DIFF
--- a/Rocket.toml
+++ b/Rocket.toml
@@ -13,3 +13,4 @@ limits = { json = "10MiB" }
 [default.databases.diesel]
 url = "db/diesel/db.sqlite"
 timeout = 10
+pool_size = 10


### PR DESCRIPTION
This fixes an issue https://github.com/virtee/reference-kbs/issues/9 where on some systems reference kbs was not able to open the database.